### PR TITLE
Fix variables to be instance scope in template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@ class monit (
   $interval   = 60,
   $delay      = undef,
   $logfile    = $monit::params::logfile,
-  $mailserver = 'localhost', 
+  $mailserver = 'localhost',
 ) inherits monit::params {
 
   if ($delay == undef) {
@@ -75,16 +75,15 @@ class monit (
 
   # Not all platforms need this
   if ($monit::params::default_conf) {
-   if ($monit::params::default_conf_tpl) {
-    file { $monit::params::default_conf:
-      ensure  => $ensure,
-      content => template("monit/$monit::params::default_conf_tpl"),
-      require => Package[$monit::params::monit_package],
+    if ($monit::params::default_conf_tpl) {
+      file { $monit::params::default_conf:
+        ensure  => $ensure,
+        content => template("monit/${monit::params::default_conf_tpl}"),
+        require => Package[$monit::params::monit_package],
+      }
+    } else {
+      fail('You need to provide config template')
     }
-
-   }
-   else { fail("You need to provide config template")}
-
   }
 
   # Template uses: $logfile

--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -45,14 +45,14 @@ define monit::monitor (
 ) {
   include monit::params
   if ($pidfile == undef) and ($matching == undef) {
-    fail("Only one of pidfile and matching must be specified.")
+    fail('Only one of pidfile and matching must be specified.')
   }
   if ($pidfile != undef) and ($matching != undef) {
-    fail("One of pidfile and matching must be specified.")
+    fail('One of pidfile and matching must be specified.')
   }
 
   # Template uses: $pidfile, $ip_port, $socket, $checks, $start_script, $stop_script, $start_timeout, $stop_timeout, $group, $uid, $gid
-  file { "${monit::params::conf_dir}/$name.conf":
+  file { "${monit::params::conf_dir}/${name}.conf":
     ensure  => $ensure,
     content => template('monit/process.conf.erb'),
     notify  => Service[$monit::params::monit_service],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class monit::params {
       $monit_service      = 'monit'
       $logfile            = '/var/log/monit'
       $logrotate_script   = '/etc/logrotate.d/monit'
-      $logrotate_source   = "logrotate.redhat.erb"
+      $logrotate_source   = 'logrotate.redhat.erb'
       $service_has_status = true
       $default_conf_tpl   = undef
     }
@@ -52,9 +52,9 @@ class monit::params {
           $logrotate_source   = 'logrotate.ubuntu.erb'
           $service_has_status = true
           case $::lsbdistrelease {
-            "10.10": { $default_conf_tpl = 'monit.default.conf.ubuntu.maverick.erb' }
-            "12.04": { $default_conf_tpl = 'monit.default.conf.ubuntu.precise.erb'}
-            "12.10": { $default_conf_tpl = 'monit.default.conf.ubuntu.quantal.erb'}
+            '10.10': { $default_conf_tpl = 'monit.default.conf.ubuntu.maverick.erb' }
+            '12.04': { $default_conf_tpl = 'monit.default.conf.ubuntu.precise.erb'}
+            '12.10': { $default_conf_tpl = 'monit.default.conf.ubuntu.quantal.erb'}
             default: { fail("Unsupported lsbdistid: ${::lsbdistid} / ${::lsbdistrelease}") }
           }
         }

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -16,8 +16,8 @@
 ##
 ## Start Monit in the background (run as a daemon):
 #
-set daemon  <%= interval %> # check services at N-second intervals
-   with start delay <%= use_delay  %> # delay the first check N*2
+set daemon  <%= @interval %> # check services at N-second intervals
+   with start delay <%= @use_delay  %> # delay the first check N*2
 #
 #
 ## Set syslog logging with the 'daemon' facility. If the FACILITY option is
@@ -52,7 +52,7 @@ set logfile <%= @logfile %>
 #                backup.bar.baz port 10025,  # backup mailserver on port 10025
 #                localhost                   # fallback relay
 #
-set mailserver <%= mailserver %>
+set mailserver <%= @mailserver %>
 
 ## By default Monit will drop alert events if no mail servers are available. 
 ## If you want to keep the alerts for later delivery retry, you can use the 


### PR DESCRIPTION
Fixing variables to be instance scope in template as part of cleaning up deprecation warnings on the puppet master.
