### PR TITLE
Feature/multiple process groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ group :test do
   gem 'puppet-lint'
   gem 'rspec-puppet', '~> 0.1.3'
 end
+
+group :development, :test do
+  gem 'rake'
+  gem 'puppetlabs_spec_helper', '<0.8'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'puppet'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     diff-lcs (1.1.3)
     facter (1.6.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,42 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
-    facter (1.6.7)
-    puppet (2.7.13)
-      facter (>= 1.5.1)
+    CFPropertyList (2.2.8)
+    diff-lcs (1.2.5)
+    facter (2.3.0)
+      CFPropertyList (~> 2.2.6)
+    hiera (1.3.4)
+      json_pure
+    json_pure (1.8.1)
+    metaclass (0.0.4)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    puppet (3.7.3)
+      facter (> 1.6, < 3)
+      hiera (~> 1.0)
+      json_pure
     puppet-lint (0.1.13)
-    rspec (2.9.0)
-      rspec-core (~> 2.9.0)
-      rspec-expectations (~> 2.9.0)
-      rspec-mocks (~> 2.9.0)
-    rspec-core (2.9.0)
-    rspec-expectations (2.9.1)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.9.0)
-    rspec-puppet (0.1.3)
+    puppetlabs_spec_helper (0.7.0)
+      mocha
+      puppet-lint
+      rake
       rspec
+      rspec-puppet
+    rake (10.3.2)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-puppet (0.1.6)
+      rspec
+    rspec-support (3.1.2)
 
 PLATFORMS
   ruby
@@ -23,4 +44,6 @@ PLATFORMS
 DEPENDENCIES
   puppet
   puppet-lint
+  puppetlabs_spec_helper (< 0.8)
+  rake
   rspec-puppet (~> 0.1.3)

--- a/spec/defines/monit_monitor_spec.rb
+++ b/spec/defines/monit_monitor_spec.rb
@@ -20,18 +20,18 @@ describe 'monit::monitor', :type => :define do
           'matching' => 'some_process_name',
         }
       }
-      it { 
+      it {
         expect { should raise_error(Puppet::Error) }
-      } 
+      }
     end
 
     context "no pidfile nor matching specified" do
       let(:title) { 'monit-monitor-no-pidfile-mathcing' }
 
       let(:params) { }
-      it { 
+      it {
         expect { should raise_error(Puppet::Error) }
-      } 
+      }
     end
 
     context "default usage (osfamily = RedHat)" do
@@ -78,6 +78,27 @@ describe 'monit::monitor', :type => :define do
           "  start program = \"/etc/init.d/monit-monitor-group start\"\n" +
           "  stop program  = \"/etc/init.d/monit-monitor-group stop\"\n" +
           "  group somegroup\n"
+        )
+      end
+    end
+
+    context "Multiple groups  (osfamily = RedHat)" do
+      let(:title) { 'monit-monitor-group' }
+
+      let(:params) {
+        {
+          'pidfile' => '/var/run/monit.pid',
+          'group'   => ['somegroup', 'othergroup'],
+        }
+      }
+
+      it 'should compile' do
+        should contain_file('/etc/monit.d/monit-monitor-group.conf').with_content(
+          "check process monit-monitor-group with pidfile /var/run/monit.pid\n" +
+          "  start program = \"/etc/init.d/monit-monitor-group start\"\n" +
+          "  stop program  = \"/etc/init.d/monit-monitor-group stop\"\n" +
+          "  group somegroup\n" +
+          "  group othergroup\n"
         )
       end
     end

--- a/templates/process.conf.erb
+++ b/templates/process.conf.erb
@@ -19,4 +19,6 @@ check process <%= @name %> matching <%= @matching %>
 <% @checks.each do |check| -%>
   <%= check %>
 <% end -%>
-  group <%= @group %>
+<% Array(@group).each do |group| -%>
+  group <%= group %>
+<% end -%>


### PR DESCRIPTION
Adds a separate group declaration for each group a monit monitored process should be in (See https://mmonit.com/monit/documentation/monit.html#SERVICE-GROUPS).

Fixes the Gemfile to support running the specs with `bundle exec rake spec`.
